### PR TITLE
Add resume download link to hero section

### DIFF
--- a/pages.html
+++ b/pages.html
@@ -28,6 +28,16 @@
                     </div>
                     <div class="md:col-span-2 text-center md:text-left">
                         <h1 class="text-4xl md:text-5xl font-bold text-white mb-4">Delivering Scalable Solutions in AI, Automation and Business Systems </h1>
+                        <div class="flex justify-center md:justify-start mb-6">
+                            <a
+                                href="https://mayur-mehta-portfolio.netlify.app/Mayur_Mehta_Resume.pdf"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="inline-flex items-center bg-brand-primary text-white px-4 py-2 rounded shadow hover:bg-brand-primary/90 transition"
+                            >
+                                Download My Resume
+                            </a>
+                        </div>
                         <p class="text-lg md:text-xl text-gray-400 max-w-3xl mx-auto md:mx-0 mb-8">
                             Hi, I'm Mayur—a technical program manager and builder passionate about turning ambitious ideas into scalable reality. From delivering automation solutions impacting $1B in annual transactions at the enterprise level to building AI-powered solutions from the ground up, I specialize in bridging business vision with technical execution. I lead cross-functional teams to design, launch, and continuously improve high-impact programs across analytics, AI, enterprise applications, and operations.
                         </p>


### PR DESCRIPTION
## Summary
- add a prominent call-to-action button in the hero section that links to a hosted PDF resume and opens in a new tab

## Testing
- not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68c86e9467208330af30354d7507d3ef