### PR TITLE
Organize home hero banner and value proposition sections

### DIFF
--- a/pages.html
+++ b/pages.html
@@ -22,7 +22,7 @@
     <div id="home" class="page">
         <section class="py-16 md:py-20">
             <div class="container mx-auto px-4">
-                <div class="grid md:grid-cols-3 gap-8 md:gap-12 items-center">
+                <section id="headline-banner" class="grid md:grid-cols-3 gap-8 md:gap-12 items-center">
                     <div class="md:col-span-1 flex justify-center md:justify-start">
                         <img src="https://mayur-mehta-portfolio.netlify.app/portfolio_profile.jpg" alt="Mayur Mehta Headshot" class="rounded-full w-56 h-56 md:w-72 md:h-72 object-cover border-4 border-gray-700 shadow-lg" onerror="this.onerror=null;this.src='https://placehold.co/288x288/1f2937/ffffff?text=MM';">
                     </div>
@@ -38,13 +38,20 @@
                                 Download My Resume
                             </a>
                         </div>
-                        <ul class="text-lg md:text-xl text-gray-400 max-w-3xl mx-auto md:mx-0 mb-8 list-disc list-inside space-y-3">
-                            <li>Directed a <span class="text-brand-primary font-semibold">40-member</span> cross-functional analytics team, delivering data pipelines and dashboards that improved visibility and forecasting for over <span class="text-brand-primary font-semibold">$20M</span> in marketing spend.</li>
-                            <li>Converted user insights into validated core personas and JTBD artifacts, securing investor readiness, aligning the product roadmap with fundraising strategy, and accelerating the launch by <span class="text-brand-primary font-semibold">3 months</span>.</li>
-                            <li>Led a global tax automation project, integrating OneSource SaaS with Oracle EBS to save <span class="text-brand-primary font-semibold">$4M</span> and ensure compliance across more than <span class="text-brand-primary font-semibold">30 markets</span>.</li>
-                        </ul>
                     </div>
-                </div>
+                </section>
+                <section id="value-proposition" class="mt-10 md:mt-12">
+                    <div class="grid md:grid-cols-3 gap-8 md:gap-12">
+                        <div class="md:col-span-2 md:col-start-2 text-center md:text-left max-w-3xl space-y-6">
+                            <p class="text-lg md:text-xl text-gray-300">From enterprise-scale transformations to rapid product acceleration, I focus on initiatives that unlock measurable growth.</p>
+                            <ul class="text-lg md:text-xl text-gray-400 list-disc list-inside space-y-3">
+                                <li>Directed a <span class="text-brand-primary font-semibold">40-member</span> cross-functional analytics team, delivering data pipelines and dashboards that improved visibility and forecasting for over <span class="text-brand-primary font-semibold">$20M</span> in marketing spend.</li>
+                                <li>Converted user insights into validated core personas and JTBD artifacts, securing investor readiness, aligning the product roadmap with fundraising strategy, and accelerating the launch by <span class="text-brand-primary font-semibold">3 months</span>.</li>
+                                <li>Led a global tax automation project, integrating OneSource SaaS with Oracle EBS to save <span class="text-brand-primary font-semibold">$4M</span> and ensure compliance across more than <span class="text-brand-primary font-semibold">30 markets</span>.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
                 <div class="mt-16 md:mt-20 text-center">
                     <blockquote class="text-2xl md:text-3xl italic text-gray-300 max-w-3xl mx-auto border-l-4 border-brand-primary pl-6">
                         "The only way to do great work is to love what you do."


### PR DESCRIPTION
## Summary
- wrap the hero image, headline, and resume link in a dedicated `headline-banner` section
- add a follow-up `value-proposition` section with introductory copy and the achievement list spaced with `space-y-6` and `max-w-3xl`

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c88292891c8330a6a0de0caa7d32e3