### PR TITLE
Refactor differentiators into responsive grid section

### DIFF
--- a/pages.html
+++ b/pages.html
@@ -38,11 +38,38 @@
                                 Download My Resume
                             </a>
                         </div>
-                        <ul class="text-lg md:text-xl text-gray-400 max-w-3xl mx-auto md:mx-0 mb-8 list-disc list-inside space-y-3">
-                            <li>Directed a <span class="text-brand-primary font-semibold">40-member</span> cross-functional analytics team, delivering data pipelines and dashboards that improved visibility and forecasting for over <span class="text-brand-primary font-semibold">$20M</span> in marketing spend.</li>
-                            <li>Converted user insights into validated core personas and JTBD artifacts, securing investor readiness, aligning the product roadmap with fundraising strategy, and accelerating the launch by <span class="text-brand-primary font-semibold">3 months</span>.</li>
-                            <li>Led a global tax automation project, integrating OneSource SaaS with Oracle EBS to save <span class="text-brand-primary font-semibold">$4M</span> and ensure compliance across more than <span class="text-brand-primary font-semibold">30 markets</span>.</li>
-                        </ul>
+                        <section id="differentiators" class="mb-8">
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                                <div class="flex items-start gap-4">
+                                    <div class="text-3xl text-brand-primary">🚀</div>
+                                    <div>
+                                        <h3 class="text-lg font-semibold text-white">Scaled Marketing Intelligence</h3>
+                                        <p class="text-gray-400 text-sm">Directed a <span class="text-brand-primary font-semibold">40-member</span> analytics squad, building pipelines and dashboards that guided <span class="text-brand-primary font-semibold">$20M</span> in spend.</p>
+                                    </div>
+                                </div>
+                                <div class="flex items-start gap-4">
+                                    <div class="text-3xl text-brand-primary">🎯</div>
+                                    <div>
+                                        <h3 class="text-lg font-semibold text-white">Focused Product Acceleration</h3>
+                                        <p class="text-gray-400 text-sm">Turned user insight into personas and JTBD artifacts that aligned roadmaps with fundraising, accelerating launch by <span class="text-brand-primary font-semibold">3 months</span>.</p>
+                                    </div>
+                                </div>
+                                <div class="flex items-start gap-4">
+                                    <div class="text-3xl text-brand-primary">🌍</div>
+                                    <div>
+                                        <h3 class="text-lg font-semibold text-white">Global Automation Leadership</h3>
+                                        <p class="text-gray-400 text-sm">Integrated OneSource SaaS with Oracle EBS to save <span class="text-brand-primary font-semibold">$4M</span> while staying compliant across <span class="text-brand-primary font-semibold">30+</span> markets.</p>
+                                    </div>
+                                </div>
+                                <div class="flex items-start gap-4">
+                                    <div class="text-3xl text-brand-primary">⚙️</div>
+                                    <div>
+                                        <h3 class="text-lg font-semibold text-white">End-to-End Ownership</h3>
+                                        <p class="text-gray-400 text-sm">Bring discovery-to-adoption rigor that ensures stakeholders receive the promised outcomes on schedule and at scale.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
                     </div>
                 </div>
                 <div class="mt-16 md:mt-20 text-center">


### PR DESCRIPTION
## Summary
- convert the hero differentiator bullets into a dedicated section placed after the value proposition
- present each differentiator as an icon + text block inside a responsive two-column grid for better balance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c88297b80c8330a40a6ddebd756c04