### PR TITLE
Add competencies section with skills and certifications

### DIFF
--- a/pages.html
+++ b/pages.html
@@ -55,8 +55,84 @@
         </section>
         <div class="container mx-auto px-4 grid grid-cols-1 lg:grid-cols-5 gap-16">
             <div class="lg:col-span-3">
+                <section id="competencies" class="pt-8">
+                    <h2 class="text-3xl font-bold text-white mb-3">Signature Competencies &amp; Certifications</h2>
+                    <p class="text-gray-400 mb-8 max-w-3xl">I combine cross-functional leadership with hands-on technical expertise to align business strategy, data, and automation. These highlights showcase the credentials and capabilities I bring to every engagement.</p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 xl:grid-cols-3">
+                        <div class="bg-gray-800/20 p-6 rounded-lg border border-gray-700/50 h-full">
+                            <div class="flex items-start gap-4">
+                                <div class="text-3xl text-brand-primary">🧠</div>
+                                <div>
+                                    <h3 class="text-lg font-semibold text-white mb-2">AI Product Strategy</h3>
+                                    <p class="text-gray-400 text-sm">Translate user insights into AI-driven roadmaps that accelerate experimentation while mitigating risk.</p>
+                                    <div class="flex flex-wrap gap-2 mt-4">
+                                        <span class="px-3 py-1 rounded-full text-xs font-medium bg-brand-primary/10 text-brand-primary border border-brand-primary/30">Machine Learning Use Cases</span>
+                                        <span class="px-3 py-1 rounded-full text-xs font-medium bg-brand-primary/10 text-brand-primary border border-brand-primary/30">Responsible AI Reviews</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bg-gray-800/20 p-6 rounded-lg border border-gray-700/50 h-full">
+                            <div class="flex items-start gap-4">
+                                <div class="text-3xl text-brand-primary">⚙️</div>
+                                <div>
+                                    <h3 class="text-lg font-semibold text-white mb-2">Automation Engineering</h3>
+                                    <p class="text-gray-400 text-sm">Deliver resilient integrations that orchestrate workflows across finance, marketing, and customer platforms.</p>
+                                    <div class="flex flex-wrap gap-2 mt-4">
+                                        <span class="px-3 py-1 rounded-full text-xs font-medium bg-brand-primary/10 text-brand-primary border border-brand-primary/30">API Design</span>
+                                        <span class="px-3 py-1 rounded-full text-xs font-medium bg-brand-primary/10 text-brand-primary border border-brand-primary/30">RPA Governance</span>
+                                        <span class="px-3 py-1 rounded-full text-xs font-medium bg-brand-primary/10 text-brand-primary border border-brand-primary/30">Compliance Automation</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bg-gray-800/20 p-6 rounded-lg border border-gray-700/50 h-full">
+                            <div class="flex items-start gap-4">
+                                <div class="text-3xl text-brand-primary">📊</div>
+                                <div>
+                                    <h3 class="text-lg font-semibold text-white mb-2">Data Governance &amp; Analytics</h3>
+                                    <p class="text-gray-400 text-sm">Build scalable data pipelines and dashboards that keep leadership aligned on performance and opportunity.</p>
+                                    <div class="flex flex-wrap gap-2 mt-4">
+                                        <span class="px-3 py-1 rounded-full text-xs font-medium bg-brand-primary/10 text-brand-primary border border-brand-primary/30">Data Quality Playbooks</span>
+                                        <span class="px-3 py-1 rounded-full text-xs font-medium bg-brand-primary/10 text-brand-primary border border-brand-primary/30">Executive Reporting</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bg-gray-800/20 p-6 rounded-lg border border-gray-700/50 h-full">
+                            <div class="flex items-start gap-4">
+                                <img src="https://img.icons8.com/color/96/amazon-web-services.png" alt="Amazon Web Services logo" class="w-14 h-14 object-contain bg-white rounded-md p-2">
+                                <div>
+                                    <h3 class="text-lg font-semibold text-white">AWS Certified Solutions Architect – Associate</h3>
+                                    <p class="text-sm text-gray-400">Amazon Web Services &middot; Issued 2023</p>
+                                    <p class="text-sm text-gray-500 mt-3">Validates the ability to design secure, high-performing cloud architectures that scale with business demand.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bg-gray-800/20 p-6 rounded-lg border border-gray-700/50 h-full">
+                            <div class="flex items-start gap-4">
+                                <img src="https://img.icons8.com/color/96/scrum.png" alt="Scrum Alliance logo" class="w-14 h-14 object-contain bg-white rounded-md p-2">
+                                <div>
+                                    <h3 class="text-lg font-semibold text-white">Certified ScrumMaster&reg; (CSM)</h3>
+                                    <p class="text-sm text-gray-400">Scrum Alliance &middot; Issued 2022</p>
+                                    <p class="text-sm text-gray-500 mt-3">Demonstrates expertise in leading high-trust agile ceremonies and enabling product teams to deliver iteratively.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bg-gray-800/20 p-6 rounded-lg border border-gray-700/50 h-full">
+                            <div class="flex items-start gap-4">
+                                <img src="https://img.icons8.com/color/96/google-logo.png" alt="Google logo" class="w-14 h-14 object-contain bg-white rounded-md p-2">
+                                <div>
+                                    <h3 class="text-lg font-semibold text-white">Google Data Analytics Professional Certificate</h3>
+                                    <p class="text-sm text-gray-400">Coursera &middot; Completed 2021</p>
+                                    <p class="text-sm text-gray-500 mt-3">Grounds analytics leadership in proven methodologies for data collection, visualization, and stakeholder storytelling.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
                 <section id="philosophy" class="pt-8">
-				  <h2 class="text-3xl font-bold text-white mb-8">How I Deliver Impact</h2>
+                                  <h2 class="text-3xl font-bold text-white mb-8">How I Deliver Impact</h2>
 				  <div class="space-y-8">
 					<div class="flex items-start gap-4">
 					  <div class="text-3xl text-brand-primary">🔑</div>


### PR DESCRIPTION
## Summary
- add a competencies section ahead of the philosophy content to spotlight signature skills
- introduce a responsive grid of cards with badges that emphasize AI, automation, and analytics capabilities
- document key certifications with logos plus issuing authority and completion year details

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8829b54d0833095055ec8d06a7fb8