### PR TITLE
Apply consistent spacing to home sections

### DIFF
--- a/pages.html
+++ b/pages.html
@@ -55,7 +55,7 @@
         </section>
         <div class="container mx-auto px-4 grid grid-cols-1 lg:grid-cols-5 gap-16">
             <div class="lg:col-span-3">
-                <section id="philosophy" class="pt-8">
+                <section id="philosophy" class="py-16 md:py-20">
 				  <h2 class="text-3xl font-bold text-white mb-8">How I Deliver Impact</h2>
 				  <div class="space-y-8">
 					<div class="flex items-start gap-4">
@@ -95,7 +95,7 @@
 					</div>
 				  </div>
 				</section>
-                <section id="core-traits" class="pt-16">
+                <section id="core-traits" class="py-16 md:py-20">
                     <h2 class="text-3xl font-bold text-white mb-8">Core Traits</h2>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div class="bg-gray-800/20 p-6 rounded-lg border border-gray-700/50">
@@ -120,7 +120,7 @@
                         </div>
                     </div>
                 </section>
-                <section id="ai-built" class="pt-16">
+                <section id="ai-built" class="py-16 md:py-20">
                     <div class="bg-gray-800/20 rounded-xl p-8 text-center border border-gray-700/50">
                         <div class="text-4xl mb-4">🤖</div>
                         <h2 class="text-2xl font-bold text-white mb-3">A Note on How This Site Was Built</h2>
@@ -131,7 +131,7 @@
                 </section>
             </div>
             <div class="lg:col-span-2">
-                <section id="contact" class="sticky top-24">
+                <section id="contact" class="sticky top-24 py-16 md:py-20">
                     <div class="bg-gray-800/50 p-8 rounded-2xl border border-gray-700">
                         <h2 class="text-2xl font-bold text-white text-center mb-6">Get In Touch</h2>
                         <form name="contact" method="POST" data-netlify="true" class="space-y-4">


### PR DESCRIPTION
## Summary
- add the shared `py-16 md:py-20` spacing classes to the philosophy, core traits, AI-built, and contact sections on the home page for uniform vertical rhythm

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8829fc2e08330b63509763086e0e4