### PR TITLE
Adjust hero layout to two-column grid

### DIFF
--- a/pages.html
+++ b/pages.html
@@ -22,7 +22,7 @@
     <div id="home" class="page">
         <section class="py-16 md:py-20">
             <div class="container mx-auto px-4">
-                <section id="headline-banner" class="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 md:gap-12 items-center">
+                <section id="headline-banner" class="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 md:gap-12 items-center md:items-start">
                     <div class="flex justify-center md:justify-start">
                         <img src="https://mayur-mehta-portfolio.netlify.app/portfolio_profile.jpg" alt="Mayur Mehta Headshot" class="rounded-full w-56 h-56 md:w-72 md:h-72 object-cover border-4 border-gray-700 shadow-lg" onerror="this.onerror=null;this.src='https://placehold.co/288x288/1f2937/ffffff?text=MM';">
                     </div>

--- a/pages.html
+++ b/pages.html
@@ -22,11 +22,11 @@
     <div id="home" class="page">
         <section class="py-16 md:py-20">
             <div class="container mx-auto px-4">
-                <section id="headline-banner" class="grid md:grid-cols-3 gap-8 md:gap-12 items-center">
-                    <div class="md:col-span-1 flex justify-center md:justify-start">
+                <section id="headline-banner" class="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 md:gap-12 items-center">
+                    <div class="flex justify-center md:justify-start">
                         <img src="https://mayur-mehta-portfolio.netlify.app/portfolio_profile.jpg" alt="Mayur Mehta Headshot" class="rounded-full w-56 h-56 md:w-72 md:h-72 object-cover border-4 border-gray-700 shadow-lg" onerror="this.onerror=null;this.src='https://placehold.co/288x288/1f2937/ffffff?text=MM';">
                     </div>
-                    <div class="md:col-span-2 text-center md:text-left">
+                    <div class="text-center md:text-left">
                         <h1 class="text-4xl md:text-5xl font-bold text-white mb-4">Delivering Scalable Solutions in AI, Automation and Business Systems </h1>
                         <div class="flex justify-center md:justify-start mb-6">
                             <a


### PR DESCRIPTION
## Summary
- wrap the homepage hero content in a responsive two-column grid
- center the hero layout with a max width constraint for better large-screen spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c887c3dde4833088b72acac7d1ffd0