### PR TITLE
Refine hero layout with floating headshot

### DIFF
--- a/pages.html
+++ b/pages.html
@@ -21,13 +21,13 @@
 <div id="pages-container">
     <div id="home" class="page">
         <section class="py-16 md:py-20">
-            <div class="container mx-auto px-4">
-                <section id="headline-banner" class="max-w-5xl mx-auto">
+            <div class="container mx-auto px-4 lg:px-6 xl:px-0">
+                <section id="headline-banner" class="max-w-6xl xl:max-w-7xl mx-auto">
                     <div class="flow-root">
                         <img
                             src="https://mayur-mehta-portfolio.netlify.app/portfolio_profile.jpg"
                             alt="Mayur Mehta Headshot"
-                            class="hero-headshot float-left mr-6 mb-4 rounded-full w-36 h-36 sm:w-48 sm:h-48 md:w-64 md:h-64 lg:w-72 lg:h-72 object-cover border-4 border-gray-700 shadow-lg"
+                            class="hero-headshot float-left mr-6 mb-4 rounded-full w-36 h-36 sm:w-48 sm:h-48 md:w-64 md:h-64 lg:w-72 lg:h-72 md:-ml-4 lg:-ml-8 xl:-ml-12 2xl:-ml-16 object-cover border-4 border-gray-700 shadow-lg"
                             onerror="this.onerror=null;this.src='https://placehold.co/288x288/1f2937/ffffff?text=MM';"
                         >
                         <div class="text-left">

--- a/pages.html
+++ b/pages.html
@@ -22,54 +22,59 @@
     <div id="home" class="page">
         <section class="py-16 md:py-20">
             <div class="container mx-auto px-4">
-                <section id="headline-banner" class="grid md:grid-cols-3 gap-8 md:gap-12 items-center">
-                    <div class="md:col-span-1 flex justify-center md:justify-start">
-                        <img src="https://mayur-mehta-portfolio.netlify.app/portfolio_profile.jpg" alt="Mayur Mehta Headshot" class="rounded-full w-56 h-56 md:w-72 md:h-72 object-cover border-4 border-gray-700 shadow-lg" onerror="this.onerror=null;this.src='https://placehold.co/288x288/1f2937/ffffff?text=MM';">
-                    </div>
-                    <div class="md:col-span-2 text-center md:text-left">
-                        <h1 class="text-4xl md:text-5xl font-bold text-white mb-4">Delivering Scalable Solutions in AI, Automation and Business Systems </h1>
-                        <div class="flex justify-center md:justify-start mb-6">
-                            <a
-                                href="https://mayur-mehta-portfolio.netlify.app/Mayur_Mehta_Resume.pdf"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="inline-flex items-center bg-brand-primary text-white px-4 py-2 rounded shadow hover:bg-brand-primary/90 transition"
-                            >
-                                Download My Resume
-                            </a>
-                        </div>
-                        <section id="differentiators" class="mb-8">
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-                                <div class="flex items-start gap-4">
-                                    <div class="text-3xl text-brand-primary">🚀</div>
-                                    <div>
-                                        <h3 class="text-lg font-semibold text-white">Scaled Marketing Intelligence</h3>
-                                        <p class="text-gray-400 text-sm">Directed a <span class="text-brand-primary font-semibold">40-member</span> analytics squad, building pipelines and dashboards that guided <span class="text-brand-primary font-semibold">$20M</span> in spend.</p>
-                                    </div>
-                                </div>
-                                <div class="flex items-start gap-4">
-                                    <div class="text-3xl text-brand-primary">🎯</div>
-                                    <div>
-                                        <h3 class="text-lg font-semibold text-white">Focused Product Acceleration</h3>
-                                        <p class="text-gray-400 text-sm">Turned user insight into personas and JTBD artifacts that aligned roadmaps with fundraising, accelerating launch by <span class="text-brand-primary font-semibold">3 months</span>.</p>
-                                    </div>
-                                </div>
-                                <div class="flex items-start gap-4">
-                                    <div class="text-3xl text-brand-primary">🌍</div>
-                                    <div>
-                                        <h3 class="text-lg font-semibold text-white">Global Automation Leadership</h3>
-                                        <p class="text-gray-400 text-sm">Integrated OneSource SaaS with Oracle EBS to save <span class="text-brand-primary font-semibold">$4M</span> while staying compliant across <span class="text-brand-primary font-semibold">30+</span> markets.</p>
-                                    </div>
-                                </div>
-                                <div class="flex items-start gap-4">
-                                    <div class="text-3xl text-brand-primary">⚙️</div>
-                                    <div>
-                                        <h3 class="text-lg font-semibold text-white">End-to-End Ownership</h3>
-                                        <p class="text-gray-400 text-sm">Bring discovery-to-adoption rigor that ensures stakeholders receive the promised outcomes on schedule and at scale.</p>
-                                    </div>
-                                </div>
+                <section id="headline-banner" class="max-w-5xl mx-auto">
+                    <div class="flow-root">
+                        <img
+                            src="https://mayur-mehta-portfolio.netlify.app/portfolio_profile.jpg"
+                            alt="Mayur Mehta Headshot"
+                            class="hero-headshot float-left mr-6 mb-4 rounded-full w-36 h-36 sm:w-48 sm:h-48 md:w-64 md:h-64 lg:w-72 lg:h-72 object-cover border-4 border-gray-700 shadow-lg"
+                            onerror="this.onerror=null;this.src='https://placehold.co/288x288/1f2937/ffffff?text=MM';"
+                        >
+                        <div class="text-left">
+                            <h1 class="text-4xl md:text-5xl font-bold text-white mb-4">Delivering Scalable Solutions in AI, Automation and Business Systems </h1>
+                            <div class="flex justify-start mb-6">
+                                <a
+                                    href="https://mayur-mehta-portfolio.netlify.app/Mayur_Mehta_Resume.pdf"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="inline-flex items-center bg-brand-primary text-white px-4 py-2 rounded shadow hover:bg-brand-primary/90 transition"
+                                >
+                                    Download My Resume
+                                </a>
                             </div>
-                        </section>
+                            <section id="differentiators" class="mb-8">
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                                    <div class="flex items-start gap-4">
+                                        <div class="text-3xl text-brand-primary">🚀</div>
+                                        <div>
+                                            <h3 class="text-lg font-semibold text-white">Scaled Marketing Intelligence</h3>
+                                            <p class="text-gray-400 text-sm">Directed a <span class="text-brand-primary font-semibold">40-member</span> analytics squad, building pipelines and dashboards that guided <span class="text-brand-primary font-semibold">$20M</span> in spend.</p>
+                                        </div>
+                                    </div>
+                                    <div class="flex items-start gap-4">
+                                        <div class="text-3xl text-brand-primary">🎯</div>
+                                        <div>
+                                            <h3 class="text-lg font-semibold text-white">Focused Product Acceleration</h3>
+                                            <p class="text-gray-400 text-sm">Turned user insight into personas and JTBD artifacts that aligned roadmaps with fundraising, accelerating launch by <span class="text-brand-primary font-semibold">3 months</span>.</p>
+                                        </div>
+                                    </div>
+                                    <div class="flex items-start gap-4">
+                                        <div class="text-3xl text-brand-primary">🌍</div>
+                                        <div>
+                                            <h3 class="text-lg font-semibold text-white">Global Automation Leadership</h3>
+                                            <p class="text-gray-400 text-sm">Integrated OneSource SaaS with Oracle EBS to save <span class="text-brand-primary font-semibold">$4M</span> while staying compliant across <span class="text-brand-primary font-semibold">30+</span> markets.</p>
+                                        </div>
+                                    </div>
+                                    <div class="flex items-start gap-4">
+                                        <div class="text-3xl text-brand-primary">⚙️</div>
+                                        <div>
+                                            <h3 class="text-lg font-semibold text-white">End-to-End Ownership</h3>
+                                            <p class="text-gray-400 text-sm">Bring discovery-to-adoption rigor that ensures stakeholders receive the promised outcomes on schedule and at scale.</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </section>
+                        </div>
                     </div>
                 </section>
                 <div class="mt-16 md:mt-20 text-center">

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,5 +1,10 @@
-body { 
-    font-family: 'Inter', sans-serif; 
+body {
+    font-family: 'Inter', sans-serif;
+}
+
+.hero-headshot {
+    shape-outside: circle(50%);
+    -webkit-shape-outside: circle(50%);
 }
 
 /* Typography & Content Styles */


### PR DESCRIPTION
## Summary
- replace the home hero grid with a single flow-root container so the headshot and introduction share one block
- float the hero image with responsive sizing and left-aligned call-to-action text for better text wrap across breakpoints
- add a CSS helper to apply a circular shape-outside so body copy curves around the profile image

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c88b85f2308330958a9a69e13e5efa